### PR TITLE
qla4xxx: Fix build on some architectures lacking 64-bit I/O

### DIFF
--- a/drivers/scsi/qla4xxx/ql4_nx.h
+++ b/drivers/scsi/qla4xxx/ql4_nx.h
@@ -775,4 +775,19 @@ struct crb_addr_pair {
 #define MIU_TEST_AGT_WRDATA_UPPER_LO	(0x0b0)
 #define	MIU_TEST_AGT_WRDATA_UPPER_HI	(0x0b4)
 
+#ifndef readq
+static inline u64 readq(void __iomem *addr)
+{
+	return readl(addr) | (((u64) readl(addr + 4)) << 32LL);
+}
+#endif
+
+#ifndef writeq
+static inline void writeq(u64 val, void __iomem *addr)
+{
+	writel(((u32) (val)), (addr));
+	writel(((u32) (val >> 32)), (addr + 4));
+}
+#endif
+
 #endif


### PR DESCRIPTION
readq() and writeq() are not defined on all archictectures.  Where
they are missing, define fallback implementations (copied from
qla2xxx).

Reference: http://bugs.debian.org/598503
Signed-off-by: Ben Hutchings <ben@decadent.org.uk>linux-2.6-oxnas